### PR TITLE
feat: Add dbt_tags__opt_in_default_naming_config to disable env management

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -16,6 +16,7 @@ vars:
   # dbt_tags__database: common  # optional, target.database if not specified
   # dbt_tags__schema: tags      # optional, target.schema if not specified
   # dbt_tags__allowed_tags: []  # optional, allow all
+  # dbt_tags__opt_in_default_naming_config: true # optional, set false to use dbt__tags__database and dbt_tags__schema values
   dbt_tags__resource_types: ["model", "snapshot", "source"] # mandatory, find tags for only configured dbt resource types
   # dbt_tags__policy_data_types: # optional, defaults to same policy name as tag name if not specified per policy
   #   - <tag-name>: ['datatype','list'] # list of tag names, assign list of datatypes. Suffixes policy name with datatypes on assigning policies to tags

--- a/macros/utils/get_resource_ns.sql
+++ b/macros/utils/get_resource_ns.sql
@@ -3,7 +3,10 @@
 {%- endmacro %}
 
 {% macro default__get_resource_ns() %}
-
-  {{ return(generate_database_name(var("dbt_tags__database", target.database)) ~ "." ~ generate_schema_name(var("dbt_tags__schema", target.schema))) }}
+  {% if var("dbt_tags__opt_in_default_naming_config", true) %}
+    {{ return(generate_database_name(var("dbt_tags__database", target.database)) ~ "." ~ generate_schema_name(var("dbt_tags__schema", target.schema))) }}
+  {% else %}
+    {{ return(var("dbt_tags__database", target.database)) ~ "." ~ var("dbt_tags__schema", target.schema)) }}
+  {% endif %}
 
 {% endmacro %}

--- a/macros/utils/get_resource_ns.yml
+++ b/macros/utils/get_resource_ns.yml
@@ -1,7 +1,11 @@
 macros:
   - name: get_resource_ns
     description: |
-      Get the full qualified name (FQN) of the schema where the resources (tags, masking policies) are persisted to.
+      Get the full qualified name (FQN) of the schema where the resources (tags, masking policies) are persisted to if 
+      dbt_tags__opt_in_default_naming_config is true. If dbt_tags__opt_in_default_naming_config is false, returns
+      the name of the defined database and schema as per dbt_tags__database and dbt_tags__schema if available, otherwise
+      returns the target.database and target.schema values. A use case is to allow all development environments
+      to reference a singular set of tags defined by Terraform.
 
       **Usage**:
       ```sql


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
resolves #19 

This is a:

- [ ] documentation update
- [ ] bug fix with no breaking changes
- [x] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->
Add variable `dbt_tags__opt_in_default_naming_config` to use `dbt_tags__database` and `dbt_tags__schema` to disable the env management from dbt.

## Checklist

- [ ] This code is associated with an Issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests)
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
  - [ ] Snowflake
- [ ] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
