### PR TITLE
fix: wrap graph usage with if exists.

### DIFF
--- a/macros/apply-tags/apply_source_column_tags.sql
+++ b/macros/apply-tags/apply_source_column_tags.sql
@@ -9,9 +9,11 @@
   {% endif %}
 
   {% set query %}
-    {%- for source in graph.sources.values() -%}
-      {{ dbt_tags.apply_column_tags_query(source) }}
-    {%- endfor %}
+    {% if execute %}
+      {%- for source in graph.sources.values() -%}
+        {{ dbt_tags.apply_column_tags_query(source) }}
+      {%- endfor %}
+    {% endif %}
   {%- endset %}
   {{return(query)}}
 

--- a/macros/utils/get_dbt_tags.sql
+++ b/macros/utils/get_dbt_tags.sql
@@ -3,18 +3,19 @@
 {%- endmacro %}
 
 {% macro default__get_dbt_tags(with_value=False, debug=False) %}
-
+  
   {% set resource_types = var('dbt_tags__resource_types') %}
   {% set found_tags = [] %}
+  {% if execute %}
 
-  {% for relation in graph.nodes.values() if (relation.resource_type | lower) in resource_types %}
-    {% do found_tags.extend(dbt_tags.get_dbt_relation_tags(relation=relation, with_value=with_value, debug=debug)) %}
-  {% endfor %}
+    {% for relation in graph.nodes.values() if (relation.resource_type | lower) in resource_types %}
+      {% do found_tags.extend(dbt_tags.get_dbt_relation_tags(relation=relation, with_value=with_value, debug=debug)) %}
+    {% endfor %}
 
-  {% for relation in graph.sources.values() if (relation.resource_type | lower) in resource_types %}
-    {% do found_tags.extend(dbt_tags.get_dbt_relation_tags(relation=relation, with_value=with_value, debug=debug)) %}
-  {% endfor %}
+    {% for relation in graph.sources.values() if (relation.resource_type | lower) in resource_types %}
+      {% do found_tags.extend(dbt_tags.get_dbt_relation_tags(relation=relation, with_value=with_value, debug=debug)) %}
+    {% endfor %}
 
+  {% endif %}
   {{ return(found_tags) }}
-
 {% endmacro %}


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
resolves #

This is a:

- [ ] documentation update
- [x] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
https://docs.getdbt.com/reference/dbt-jinja-functions/graph
Using `dbt_tags.create-tags()` in the post-hook causes runtime error because 
> the model entries in the graph dictionary will be incomplete or incorrect during parsing.
This change allows 
```
 {% if flags.WHICH in ('run', 'build') %}
  {{ dbt_tags.create-tags() }}
  {{ dbt_tags.apply_column_tags() }}
{% endif %}
```
## Checklist

- [ ] This code is associated with an Issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests)
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
  - [x] Snowflake
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
