### PR TITLE
docs: correct default behavior for source column tagging

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -180,11 +180,18 @@ on-run-start:
     {{ dbt_tags.apply_source_column_tags() }}
 ```
 
-In this type of the resource, we implicitly control the enablement of the run by using `dbt_tags__tag_source_columns` variable (`False` by default).
-Therefore, for the live run, we need to run dbt with `dbt_tags__tag_source_columns: true`, for example:
+In this type of the resource, we implicitly control the enablement of the run by using `dbt_tags__tag_source_columns` variable (`True` by default).
+To disable source column tagging, set `dbt_tags__tag_source_columns: false`:
 
 ```shell
-dbt build -s ... --vars '{dbt_tags__tag_source_columns: true}'
+dbt build -s ... --vars '{dbt_tags__tag_source_columns: false}'
+```
+
+Alternatively, remove `source` from `dbt_tags__resource_types` to exclude sources from tag discovery entirely:
+
+```yaml
+vars:
+  dbt_tags__resource_types: ["model", "snapshot"]
 ```
 
 ## 7. Apply masking policies to tags

--- a/integration_tests/models/behavior/verify_if_masking_policies_applied_correctly.sql
+++ b/integration_tests/models/behavior/verify_if_masking_policies_applied_correctly.sql
@@ -21,6 +21,7 @@ with dbt_project_tags as (
       {%- if masking_policy %}
         {% for policy_data_types in policy_data_types_list if item.tag in policy_data_types.keys() %}
           {% for datatype in policy_data_types.values() | first %}
+            {#-- masking policy name == item.tag by convention (macro: create_masking_policy__<tag>) --#}
             {%- set masking_policy_name = item.tag ~ "_" ~ datatype %}
 
     select

--- a/integration_tests/models/behavior/verify_if_masking_policies_created_correctly.sql
+++ b/integration_tests/models/behavior/verify_if_masking_policies_created_correctly.sql
@@ -19,6 +19,7 @@ with dbt_project_masking_policies as (
     {%- set masking_policy = dbt_tags.get_masking_policy_for_tag(item.tag) %}
         {% for policy_data_types in policy_data_types_list if item.tag in policy_data_types.keys() %}
           {% for datatype in policy_data_types.values() | first %}
+            {#-- masking policy name == item.tag by convention (macro: create_masking_policy__<tag>) --#}
             {%- set masking_policy_name = item.tag ~ "_" ~ datatype %}
     select
         lower('{{ item.tag }}') as tag,

--- a/macros/apply-tags/apply_source_column_tags.sql
+++ b/macros/apply-tags/apply_source_column_tags.sql
@@ -4,7 +4,7 @@
 
 {% macro default__apply_source_column_tags() %}
 
-  {% if not execute or not var('dbt_tags__tag_source_columns',true)%}
+  {% if not execute or not var('dbt_tags__tag_source_columns', true)%}
     {{ return("") }}
   {% endif %}
 


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
resolves #

This is a:

- [x] documentation update
- [ ] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change


