### PR TITLE
fix: use supported macro argument types

### DIFF
--- a/macros/apply-tags/apply_column_tags_query.yml
+++ b/macros/apply-tags/apply_column_tags_query.yml
@@ -12,5 +12,5 @@ macros:
       ```
     arguments:
       - name: resource
-        type: graph.node
+        type: any
         description: graph.node object, This contains information about complete resource like resource's columns, including tags that are defined for each column etc.

--- a/macros/utils/extract_dbt_object_tags.yml
+++ b/macros/utils/extract_dbt_object_tags.yml
@@ -29,7 +29,7 @@ macros:
       ```
     arguments:
       - name: obj
-        type: object
+        type: any
         description: The dbt object (relation, column) to extract tags from.
       - name: debug
         type: boolean

--- a/macros/utils/get_table_type.yml
+++ b/macros/utils/get_table_type.yml
@@ -19,5 +19,5 @@ macros:
       **Output**: String value - either 'iceberg' or 'standard'
     arguments:
       - name: resource
-        type: object
+        type: any
         description: The dbt resource object (model, source, etc.) to check for table type


### PR DESCRIPTION
## Summary
- replace unsupported macro argument types with `any` in package docs
- keep existing descriptions for the dbt resource/object shapes

## Verification
- `node -e` validation confirmed no `graph.node` or `object` argument types remain in the issue files
- `git diff --check`

Closes #55
